### PR TITLE
Update roda-http-auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'pg', '0.18.4'
 gem 'puma', '3.12.0'
 gem 'rack-protection', '1.5.5'
 gem 'roda', '~> 2.26.0'
-gem 'roda-http-auth', '~> 0.1.2'
+gem 'roda-http-auth', '~> 0.2.0'
 gem 'sequel', '4.35.0'
 gem 'simplecov', '0.16.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     rake (12.3.1)
     roda (2.26.0)
       rack
-    roda-http-auth (0.1.2)
+    roda-http-auth (0.2.0)
       roda (>= 2.0, < 4.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -93,7 +93,7 @@ DEPENDENCIES
   rack-test (= 1.0.0)
   rake (= 12.3.1)
   roda (~> 2.26.0)
-  roda-http-auth (~> 0.1.2)
+  roda-http-auth (~> 0.2.0)
   rspec (= 3.7.0)
   rspec_sequel_matchers (= 0.4.0)
   rubocop


### PR DESCRIPTION
The 0.2.0 version enables you to provide custom blocks for when you are unauthenticated in the context of the instance (e.g. serving specific views, etc).